### PR TITLE
Fix button maps

### DIFF
--- a/game.libretro.mupen64plus-nx/resources/buttonmap.xml
+++ b/game.libretro.mupen64plus-nx/resources/buttonmap.xml
@@ -4,17 +4,18 @@
 		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
 		<feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
 		<feature name="cup" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT" direction="up"/>
-		<feature name="cdown" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT" direction="down"/>
 		<feature name="cright" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT" direction="right"/>
+		<feature name="cdown" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT" direction="down"/>
 		<feature name="cleft" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT" direction="left"/>
+		<feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
 		<feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
-		<feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
 		<feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+		<feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
 		<feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
 		<feature name="leftbumper" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
 		<feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
 		<feature name="z" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
 		<feature name="analogstick" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT"/>
-        <feature name="motor" mapto="RETRO_RUMBLE_WEAK"/>
+		<feature name="motor" mapto="RETRO_RUMBLE_WEAK"/>
 	</controller>
 </buttonmap>


### PR DESCRIPTION
Add the missing START button and fix the button order and some white spaces along the way. The order of buttons is now in sync with the controller layout.xml.

I was unable to start Mario 64 because of the "Press START button" in the beginning.